### PR TITLE
feat: Add margins, stretch background image, and increase font size

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -3,7 +3,6 @@
 }
 
 body {
-  height: 100vh;
   width: 100vw;
   display: flex;
   flex-direction: column;
@@ -49,6 +48,8 @@ body {
 
 .dashboard {
   background-image: url(https://img.atlasobscura.com/8WQhQ0SjlrVkKHDTqElxCviWT4wt9VeuDr8LWrgex8A/rs:fill:12000:12000/q:81/sm:1/scp:1/ar:1/aHR0cHM6Ly9hdGxh/cy1kZXYuczMuYW1h/em9uYXdzLmNvbS91/cGxvYWRzL2Fzc2V0/cy8zMjlmMmE0Yzgw/NDZkZjFlZDlfRDNL/NTFKLmpwZw.jpg);
+  width: 100vw;
+  background-size: cover;
 }
 
 .my-trips {
@@ -68,18 +69,18 @@ body {
 .main-section {
   display: flex;
   flex-direction: row;
-  justify-content: space-around;
+  /* justify-content: space-around; */
 }
 
 .left-section {
   display: flex;
   flex-direction: column;
-  margin-left: 0em;
-  margin-right: 4em;
+  margin-left: 9em;
+  margin-right: 1em;
 }
 
 aside {
-  margin-right: 4em;
+  margin-right: 2em;
 }
 
 form, 
@@ -92,7 +93,7 @@ form,
 .second-article,
 .third-article,
 aside {
-  padding: 1em 2em 1em 2em;
+  padding: 0.5em 2em 1em 2em;
   margin-bottom: 2em;
 }
 
@@ -102,13 +103,13 @@ aside {
   align-items: center;
   background-color: rgba(255, 255, 255, 0.8);
   border-radius: 10px;
-  margin-left: 3em;
+  margin-left: 4em;
 }
 
 .second-article {
   background-color: rgba(255, 255, 255, 0.8);
   border-radius: 10px;
-  margin-left: 3em;
+  margin-left: 4em;
 }
 
 .third-article {
@@ -179,15 +180,18 @@ form p,
 }
 
 .estimate {
+  font-size: 20px;
   color: rgb(3, 122, 3);
+  margin-bottom: 0em;
 }
 
 input {
   margin-bottom: 2em;
+  font-size: 18px;
 }
 
 .submit-button {
-  margin-left: 20em;
+  margin-left: 21em;
   margin-top: 3em;
   padding: 0.4em 1em 0.4em 1em;
   font-size: 20px;


### PR DESCRIPTION
I added "background-size: cover" to stretch the background image on the dashboard. I also got rid of "justify-content: space-around" and added margins instead to decrease the space between the left section and aside. Changes also include increasing the font size of input fields for better visibility. 